### PR TITLE
Fix theme toggle dark mode activation (fixes #10)

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,14 +25,18 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function toggleTheme() {
+    const body = document.body;
     const themeIcon = document.querySelector('.theme-icon');
     
-    if (themeIcon.textContent === '🌙') {
+    body.classList.toggle('dark-mode');
+    
+    if (body.classList.contains('dark-mode')) {
         themeIcon.textContent = '☀️';
     } else {
         themeIcon.textContent = '🌙';
     }
 }
+
 
 function switchTab(tabName) {
     const tabs = document.querySelectorAll('.tab-content');


### PR DESCRIPTION
Bug #10: Theme toggle icon changes but the page does not switch to dark mode. 
Added logic to toggle the 'dark-mode' class on the body element.
